### PR TITLE
api docs - remove langKey parameter from $translate.instant method

### DIFF
--- a/partials/api/pascalprecht.translate.$translate.html
+++ b/partials/api/pascalprecht.translate.$translate.html
@@ -37,13 +37,13 @@ and optional interpolate parameters to translate contents.</p>
 </div></td></tr></tbody></table><h5 id="methods_fallbacklanguage_returns">Returns</h5><table class="variables-matrix"><tr><td><a href="" class="label type-hint type-hint-string">string||array</a></td><td><div class="pascalprecht-translate-translate-fallbacklanguage-page"><p>fallback language key</p>
 </div></td></tr></table></div>
 </li>
-<li><h3 id="methods_instant">instant(langKey, translationId, interpolateParams)</h3>
+<li><h3 id="methods_instant">instant(translationId, interpolateParams)</h3>
 <div class="instant"><div class="pascalprecht-translate-translate-instant-page"><p>Returns a translation instantly from the internal state of loaded translation. All rules
-regarding the current language, the preferred language of even fallback languages will be
+regarding the current language, the preferred language and even fallback languages will be
 used except any promise handling. If a language was not found, an asynchronous loading
 will be invoked in the background.</p>
-</div><h5 id="methods_instant_parameters">Parameters</h5><table class="variables-matrix table table-bordered table-striped"><thead><tr><th>Param</th><th>Type</th><th>Details</th></tr></thead><tbody><tr><td>langKey</td><td><a href="" class="label type-hint type-hint-string">string</a></td><td><div class="pascalprecht-translate-translate-instant-page"><p>The language to translate to.</p>
-</div></td></tr><tr><td>translationId</td><td><a href="" class="label type-hint type-hint-string">string</a></td><td><div class="pascalprecht-translate-translate-instant-page"><p>Translation ID</p>
+</div><h5 id="methods_instant_parameters">Parameters</h5><table class="variables-matrix table table-bordered table-striped"><thead><tr><th>Param</th><th>Type</th><th>Details</th></tr></thead><tbody>
+<tr><td>langKey</td><td><a href="" class="label type-hint type-hint-string">string</a></td><td><tr><td>translationId</td><td><a href="" class="label type-hint type-hint-string">string</a></td><td><div class="pascalprecht-translate-translate-instant-page"><p>Translation ID</p>
 </div></td></tr><tr><td>interpolateParams</td><td><a href="" class="label type-hint type-hint-object">object</a></td><td><div class="pascalprecht-translate-translate-instant-page"><p>Params</p>
 </div></td></tr></tbody></table><h5 id="methods_instant_returns">Returns</h5><table class="variables-matrix"><tr><td><a href="" class="label type-hint type-hint-string">string</a></td><td><div class="pascalprecht-translate-translate-instant-page"><p>translation</p>
 </div></td></tr></table></div>


### PR DESCRIPTION
Looks like the docs for the $translate.instant method had the langKey param by mistake.
